### PR TITLE
Explicit Specification of Database and Schema

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -3,6 +3,9 @@ CREATE OR REPLACE DATABASE sales_intelligence;
 CREATE OR REPLACE SCHEMA sales_intelligence.data;
 CREATE OR REPLACE WAREHOUSE sales_intelligence_wh;
 
+USE DATABASE sales_intelligence;
+USE SCHEMA data;
+
 -- Create tables for sales data
 CREATE TABLE sales_conversations (
     conversation_id VARCHAR,


### PR DESCRIPTION
When I proceeded with the tutorial using this script as-is, a 404 error was returned when I attempted to ask a question in the chat.

The issue was that the database and schema were not explicitly specified, resulting in the data and semantic model being created in the public schema.