### PR TITLE
Replace unsupported claude-4-sonnet with claude-3-5-sonnet

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -24,7 +24,7 @@ def run_snowflake_query(query):
 def snowflake_api_call(query: str, limit: int = 10):
     
     payload = {
-        "model": "claude-4-sonnet",
+        "model": "claude-3-5-sonnet",
         "messages": [
             {
                 "role": "user",


### PR DESCRIPTION
claude-3-5-sonnet is the default in Cortex Playground, assuming this is Streamlit's preferred model for Cortex Agents. [Documentation](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents#supported-models) lists claude-3-5-sonnet as supported

Closes https://github.com/Snowflake-Labs/sfquickstarts/issues/2236